### PR TITLE
fix: handle absolute path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,13 +337,13 @@ function rebootTemplateWatcher(context) {
         ignoreInitial: true,
       })
 
-      context.watcher.on('add', (path) => {
-        context.changedFiles.add('./' + path)
+      context.watcher.on('add', (file) => {
+        context.changedFiles.add(path.resolve('.', file))
         touch(context.touchFile.name)
       })
 
-      context.watcher.on('change', (path) => {
-        context.changedFiles.add('./' + path)
+      context.watcher.on('change', (file) => {
+        context.changedFiles.add(path.resolve('.', file))
         touch(context.touchFile.name)
       })
     })


### PR DESCRIPTION
This resolve an HMR issue when the file is an absolute path, using `path.resolve` normalise and handles the correct behaviour for us.