### PR TITLE
Bust persistent cache (webpack 5) on module load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "object-hash": "^2.1.1",
         "postcss-selector-parser": "^6.0.4",
         "quick-lru": "^5.1.1",
-        "tailwindcss": "^2.0.3",
-        "tmp": "^0.2.1"
+        "tailwindcss": "^2.0.3"
       },
       "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.2.0",
@@ -7157,6 +7156,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8306,17 +8306,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.4",
@@ -14409,6 +14398,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -15322,14 +15312,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "requires": {
-        "rimraf": "^3.0.0"
-      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "object-hash": "^2.1.1",
     "postcss-selector-parser": "^6.0.4",
     "quick-lru": "^5.1.1",
-    "tailwindcss": "^2.0.3",
-    "tmp": "^0.2.1"
+    "tailwindcss": "^2.0.3"
   },
   "peerDependencies": {
     "postcss": "^8.2.6"


### PR DESCRIPTION
**Edit: 2 seconds after opening this I realised there's already [a PR](https://github.com/tailwindlabs/tailwindcss-jit/pull/5) for this 🤦** 

webpack 5 has [a persistent cache option](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching). This stores cache on the filesystem so that it can be reused across builds. Our current implementation has an issue with stale CSS when this option is enabled.

How to reproduce the issue in [a Next.js app](https://github.com/tailwindlabs/jit-next):

1. Set `future.webpack5` to `true` in `next.config.js`:
  ```js
  module.exports = {
    future: { webpack5: true },
  }
  ```
2. Delete the `.next` directory if it exists
3. `npm run dev`
4. We register a touch file as a dependency of our CSS build. This touch file has a random filename.
5. Close the dev server (i.e. `ctrl + c`)
6. `npm run dev`
7. At this point webpack checks whether the dependencies have changed. Our config and touch file have not changed so the CSS from the previous dev process is reused (**our module is loaded but the PostCSS plugin function does _not_ run**). The CSS is now stale. Any changes made to template files since closing the first dev server will not be reflected in the CSS output.
8. Any further changes to templates will continue to be ignored because the original touch file will remain untouched going forward (it has a random file name and we no longer know what it is)

### Solution

This PR proposes _a_ solution to this problem:

- All touch files are stored in a common directory: `path.join(os.homedir() || os.tmpdir(), '.tailwindcss', 'touch')`
- Because we know where all of the touch files are we can invalidate the cache on module load by deleting them all. This solves the problem of not knowing our previous touch file name: we don't know which file it is exactly but we know which directory it's in.

#### Why `os.homedir()`?

The home directory seems like a more stable place to put the touch files. I don't fully understand tmp directories or when and why they change. My concern would be that `os.tmpdir()` starts returning a different directory name but the previous one still exists.

In terms of whether this is acceptable to do, my home directory looks like this:

![image](https://user-images.githubusercontent.com/2615508/109803771-5a8abb00-7c19-11eb-94b5-495c8f25e6a8.png)

I looked at the source code for [`degit`](https://github.com/Rich-Harris/degit) and it uses the `home-or-tmp` module to pick a folder (the module is literally `module.exports = os.homedir() || os.tmpdir()`)