### PR TITLE
feat: import prefixSelector

### DIFF
--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -14,6 +14,7 @@ const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').
 const parseObjectStyles = require('tailwindcss/lib/util/parseObjectStyles').default
 const getModuleDependencies = require('tailwindcss/lib/lib/getModuleDependencies').default
 const escapeClassName = require('tailwindcss/lib/util/escapeClassName').default
+const prefixSelector = require('tailwindcss/lib/util/prefixSelector').default
 
 const resolveConfig = require('tailwindcss/resolveConfig')
 


### PR DESCRIPTION
Looks like [`prefixSelector`](https://github.com/tailwindlabs/tailwindcss-jit/blob/c0f01a6926cb63dc44f32431e559158ff6dc2198/src/lib/setupContext.js#L349) was never imported and hence it breaks the build:

```zsh
ReferenceError: prefixSelector is not defined
    at applyConfiguredPrefix (/satellite/node_modules/@tailwindcss/jit/src/lib/setupContext.js:349:5)
    at module.exports (/satellite/src/InstantSearch/InstantSearch.tailwind.js:10:8)
    at registerPlugins (/satellite/node_modules/@tailwindcss/jit/src/lib/setupContext.js:579:7)
    at /satellite/node_modules/@tailwindcss/jit/src/lib/setupContext.js:768:5
    at /satellite/node_modules/@tailwindcss/jit/src/index.js:34:49
    at LazyResult.runOnRoot (/satellite/node_modules/postcss/lib/lazy-result.js:303:16)
    at LazyResult.runAsync (/satellite/node_modules/postcss/lib/lazy-result.js:355:26)
    at async Promise.all (index 0)
```

