### PR TITLE
Escape commas in class names to workaround minifier bug

### DIFF
--- a/src/corePlugins/animation.js
+++ b/src/corePlugins/animation.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 const parseAnimationValue = require('tailwindcss/lib/util/parseAnimationValue').default
 

--- a/src/corePlugins/backgroundColor.js
+++ b/src/corePlugins/backgroundColor.js
@@ -1,9 +1,8 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.backgroundColor)

--- a/src/corePlugins/backgroundImage.js
+++ b/src/corePlugins/backgroundImage.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/backgroundOpacity.js
+++ b/src/corePlugins/backgroundOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme, addVariant, e } }) {
   matchUtilities({

--- a/src/corePlugins/backgroundPosition.js
+++ b/src/corePlugins/backgroundPosition.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/backgroundSize.js
+++ b/src/corePlugins/backgroundSize.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/borderColor.js
+++ b/src/corePlugins/borderColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.borderColor)

--- a/src/corePlugins/borderOpacity.js
+++ b/src/corePlugins/borderOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/borderRadius.js
+++ b/src/corePlugins/borderRadius.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/borderWidth.js
+++ b/src/corePlugins/borderWidth.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/boxShadow.js
+++ b/src/corePlugins/boxShadow.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 let transformValue = transformThemeValue('boxShadow')

--- a/src/corePlugins/cursor.js
+++ b/src/corePlugins/cursor.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/divideColor.js
+++ b/src/corePlugins/divideColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.divideColor)

--- a/src/corePlugins/divideOpacity.js
+++ b/src/corePlugins/divideOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/divideWidth.js
+++ b/src/corePlugins/divideWidth.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ addUtilities, matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/fill.js
+++ b/src/corePlugins/fill.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.fill)

--- a/src/corePlugins/flex.js
+++ b/src/corePlugins/flex.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/flexGrow.js
+++ b/src/corePlugins/flexGrow.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/flexShrink.js
+++ b/src/corePlugins/flexShrink.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/fontFamily.js
+++ b/src/corePlugins/fontFamily.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/fontSize.js
+++ b/src/corePlugins/fontSize.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 const { isPlainObject } = require('../lib/utils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/fontWeight.js
+++ b/src/corePlugins/fontWeight.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/gap.js
+++ b/src/corePlugins/gap.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gradientColorStops.js
+++ b/src/corePlugins/gradientColorStops.js
@@ -1,9 +1,8 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
 const toRgba = require('tailwindcss/lib/util/withAlphaVariable').toRgba
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 function transparentTo(value) {
   if (typeof value === 'function') {

--- a/src/corePlugins/gridAutoColumns.js
+++ b/src/corePlugins/gridAutoColumns.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asList } = require('../pluginUtils')
+const { asList, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gridAutoRows.js
+++ b/src/corePlugins/gridAutoRows.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asList } = require('../pluginUtils')
+const { asList, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gridColumn.js
+++ b/src/corePlugins/gridColumn.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/gridColumnEnd.js
+++ b/src/corePlugins/gridColumnEnd.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/gridColumnStart.js
+++ b/src/corePlugins/gridColumnStart.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/gridRow.js
+++ b/src/corePlugins/gridRow.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/gridRowEnd.js
+++ b/src/corePlugins/gridRowEnd.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gridRowStart.js
+++ b/src/corePlugins/gridRowStart.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gridTemplateColumns.js
+++ b/src/corePlugins/gridTemplateColumns.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asList } = require('../pluginUtils')
+const { asList, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/gridTemplateRows.js
+++ b/src/corePlugins/gridTemplateRows.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asList } = require('../pluginUtils')
+const { asList, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/height.js
+++ b/src/corePlugins/height.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/inset.js
+++ b/src/corePlugins/inset.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/letterSpacing.js
+++ b/src/corePlugins/letterSpacing.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/lineHeight.js
+++ b/src/corePlugins/lineHeight.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/listStyleType.js
+++ b/src/corePlugins/listStyleType.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/margin.js
+++ b/src/corePlugins/margin.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/maxHeight.js
+++ b/src/corePlugins/maxHeight.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/maxWidth.js
+++ b/src/corePlugins/maxWidth.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/minHeight.js
+++ b/src/corePlugins/minHeight.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/minWidth.js
+++ b/src/corePlugins/minWidth.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/objectPosition.js
+++ b/src/corePlugins/objectPosition.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {

--- a/src/corePlugins/opacity.js
+++ b/src/corePlugins/opacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/order.js
+++ b/src/corePlugins/order.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/outline.js
+++ b/src/corePlugins/outline.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/padding.js
+++ b/src/corePlugins/padding.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/placeholderColor.js
+++ b/src/corePlugins/placeholderColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.placeholderColor)

--- a/src/corePlugins/placeholderOpacity.js
+++ b/src/corePlugins/placeholderOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/ringColor.js
+++ b/src/corePlugins/ringColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.ringColor)

--- a/src/corePlugins/ringOffsetColor.js
+++ b/src/corePlugins/ringOffsetColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.ringOffsetColor)

--- a/src/corePlugins/ringOffsetWidth.js
+++ b/src/corePlugins/ringOffsetWidth.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/ringOpacity.js
+++ b/src/corePlugins/ringOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/ringWidth.js
+++ b/src/corePlugins/ringWidth.js
@@ -1,7 +1,6 @@
 const dlv = require('dlv')
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const toRgba = require('tailwindcss/lib/util/withAlphaVariable').toRgba
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 function safeCall(callback, defaultValue) {
   try {

--- a/src/corePlugins/rotate.js
+++ b/src/corePlugins/rotate.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asAngle } = require('../pluginUtils')
+const { asAngle, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/scale.js
+++ b/src/corePlugins/scale.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/skew.js
+++ b/src/corePlugins/skew.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asAngle } = require('../pluginUtils')
+const { asAngle, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/space.js
+++ b/src/corePlugins/space.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, addUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/stroke.js
+++ b/src/corePlugins/stroke.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.stroke)

--- a/src/corePlugins/strokeWidth.js
+++ b/src/corePlugins/strokeWidth.js
@@ -1,6 +1,5 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/textColor.js
+++ b/src/corePlugins/textColor.js
@@ -1,8 +1,7 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
 const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
 const withAlphaVariable = require('tailwindcss/lib/util/withAlphaVariable').default
 const toColorValue = require('tailwindcss/lib/util/toColorValue').default
-const { asColor } = require('../pluginUtils')
+const { asColor, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let colorPalette = flattenColorPalette(theme.textColor)

--- a/src/corePlugins/textOpacity.js
+++ b/src/corePlugins/textOpacity.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/transformOrigin.js
+++ b/src/corePlugins/transformOrigin.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/transitionDelay.js
+++ b/src/corePlugins/transitionDelay.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/transitionDuration.js
+++ b/src/corePlugins/transitionDuration.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/transitionProperty.js
+++ b/src/corePlugins/transitionProperty.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   let defaultTimingFunction = theme.transitionTimingFunction.DEFAULT

--- a/src/corePlugins/transitionTimingFunction.js
+++ b/src/corePlugins/transitionTimingFunction.js
@@ -1,4 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
+const { nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/translate.js
+++ b/src/corePlugins/translate.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/width.js
+++ b/src/corePlugins/width.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asLength } = require('../pluginUtils')
+const { asLength, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/corePlugins/zIndex.js
+++ b/src/corePlugins/zIndex.js
@@ -1,5 +1,4 @@
-const nameClass = require('tailwindcss/lib/util/nameClass').default
-const { asValue } = require('../pluginUtils')
+const { asValue, nameClass } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -1,7 +1,6 @@
 const postcss = require('postcss')
 const { resolveMatches } = require('./generateRules')
-const { bigSign } = require('./utils')
-const escape = require('tailwindcss/lib/util/escapeClassName').default
+const { bigSign, escapeClassName } = require('./utils')
 
 function buildApplyCache(applyCandidates, context) {
   for (let candidate of applyCandidates) {
@@ -85,7 +84,7 @@ function expandApplyAtRules(context) {
           .map((s) => {
             let replaced = []
             for (let utilitySelector of utilitySelectors.split(/\s*,\s*/g)) {
-              let replacedSelector = utilitySelector.replace(`.${escape(candidate)}`, s)
+              let replacedSelector = utilitySelector.replace(`.${escapeClassName(candidate)}`, s)
               if (replacedSelector === utilitySelector) {
                 continue
               }

--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -13,14 +13,13 @@ const LRU = require('quick-lru')
 const transformThemeValue = require('tailwindcss/lib/util/transformThemeValue').default
 const parseObjectStyles = require('tailwindcss/lib/util/parseObjectStyles').default
 const getModuleDependencies = require('tailwindcss/lib/lib/getModuleDependencies').default
-const escapeClassName = require('tailwindcss/lib/util/escapeClassName').default
 const prefixSelector = require('tailwindcss/lib/util/prefixSelector').default
 
 const resolveConfig = require('tailwindcss/resolveConfig')
 
 const sharedState = require('./sharedState')
 const corePlugins = require('../corePlugins')
-const { isPlainObject } = require('./utils')
+const { isPlainObject, escapeClassName } = require('./utils')
 const { isBuffer } = require('util')
 
 let contextMap = sharedState.contextMap

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,8 @@
 const postcss = require('postcss')
+const tailwindUtils = {
+  escapeClassName: require('tailwindcss/lib/util/escapeClassName').default,
+  nameClass: require('tailwindcss/lib/util/nameClass').default,
+}
 
 // Takes our lightweight rule structure and turns it into a PostCSS node.
 // This is likely a hot path and should be as optimized as possible. We
@@ -66,8 +70,24 @@ function isPlainObject(value) {
   return prototype === null || prototype === Object.prototype
 }
 
+// workaround for minifier bug which splits selectors by commas,
+// even when they are escaped (e.g. \,)
+function escapeCommas(className) {
+  return className.replace(/\\,/g, '\\2c ')
+}
+
+function escapeClassName(...args) {
+  return escapeCommas(tailwindUtils.escapeClassName(...args))
+}
+
+function nameClass(...args) {
+  return escapeCommas(tailwindUtils.nameClass(...args))
+}
+
 module.exports = {
   toPostCssNode,
   bigSign,
   isPlainObject,
+  escapeClassName,
+  nameClass,
 }

--- a/src/pluginUtils.js
+++ b/src/pluginUtils.js
@@ -1,6 +1,7 @@
 const selectorParser = require('postcss-selector-parser')
 const postcss = require('postcss')
 const { toRgba } = require('tailwindcss/lib/util/withAlphaVariable')
+const { nameClass } = require('./lib/utils')
 
 function updateAllClasses(selectors, updateClass) {
   let parser = selectorParser((selectors) => {
@@ -124,6 +125,7 @@ function asUnit(modifier, units, lookup = {}) {
 }
 
 module.exports = {
+  nameClass,
   updateAllClasses,
   updateLastClasses,
   transformAllSelectors,

--- a/tests/00-kitchen-sink.test.css
+++ b/tests/00-kitchen-sink.test.css
@@ -274,7 +274,7 @@ div {
   --tw-scale-x: 0.5;
   --tw-scale-y: 0.5;
 }
-.grid-cols-\[200px\,repeat\(auto-fill\,minmax\(15\%\,100px\)\)\,300px\] {
+.grid-cols-\[200px\2c repeat\(auto-fill\2c minmax\(15\%\2c 100px\)\)\2c 300px\] {
   grid-template-columns: 200px repeat(auto-fill, minmax(15%, 100px)) 300px;
 }
 .bg-black {

--- a/tests/08-arbitrary-values.test.css
+++ b/tests/08-arbitrary-values.test.css
@@ -25,7 +25,7 @@
 .rotate-\[1\.5turn\] {
   --tw-rotate: 1.5turn;
 }
-.grid-cols-\[200px\,repeat\(auto-fill\,minmax\(15\%\,100px\)\)\,300px\] {
+.grid-cols-\[200px\2c repeat\(auto-fill\2c minmax\(15\%\2c 100px\)\)\2c 300px\] {
   grid-template-columns: 200px repeat(auto-fill, minmax(15%, 100px)) 300px;
 }
 .space-x-\[20cm\] > :not([hidden]) ~ :not([hidden]) {
@@ -56,18 +56,18 @@
 .bg-\[\#0000ffcc\] {
   background-color: #0000ffcc;
 }
-.bg-\[rgb\(123\,123\,123\)\] {
+.bg-\[rgb\(123\2c 123\2c 123\)\] {
   --tw-bg-opacity: 1;
   background-color: rgba(123, 123, 123, var(--tw-bg-opacity));
 }
-.bg-\[rgba\(123\,123\,123\,0\.5\)\] {
+.bg-\[rgba\(123\2c 123\2c 123\2c 0\.5\)\] {
   background-color: rgba(123, 123, 123, 0.5);
 }
-.bg-\[hsl\(0\,100\%\,50\%\)\] {
+.bg-\[hsl\(0\2c 100\%\2c 50\%\)\] {
   --tw-bg-opacity: 1;
   background-color: rgba(255, 0, 0, var(--tw-bg-opacity));
 }
-.bg-\[hsla\(0\,100\%\,50\%\,0\.3\)\] {
+.bg-\[hsla\(0\2c 100\%\2c 50\%\2c 0\.3\)\] {
   background-color: hsla(0, 100%, 50%, 0.3);
 }
 .bg-opacity-\[0\.11\] {


### PR DESCRIPTION
Fixes #45

There seems to be a bug in cssnano ([seen in the playground here](https://cssnano.co/playground#eyJpbnB1dCI6Ii5ncmlkLWNvbHMtXFxbMWZyXFwsMTI4cHhcXF0ge1xuICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogMWZyIDEyOHB4O1xufVxuIiwiY29uZmlnIjoiLy8gY3NzbmFubyBjb25maWdcbntcbiAgICBcInByZXNldFwiOiBcImRlZmF1bHRcIlxufVxuIn0=)) which splits selectors by commas, even when they are escaped, for example:

```css
/* Input */
.grid-cols-\[1fr\,128px\] {
  grid-template-columns: 1fr 128px;
}

/* Output */
128px\],.grid-cols-\[1fr\{grid-template-columns:1fr 128px}
```

This PR works around this by adding two new util functions which extend the ones found in `tailwindcss`. These functions replace commas with `\2c ` to avoid the issue.