### PR TITLE
Center readme banner and use absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-![Tailwind CSS Just-In-Time](.github/logo.svg?raw=true)
-
 <p align="center">
+    ![Tailwind CSS Just-In-Time](https://raw.githubusercontent.com/tailwindlabs/tailwindcss-jit/main/.github/logo.svg)
+
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/releases"><img src="https://img.shields.io/npm/v/@tailwindcss/jit" alt="Latest Release"></a>
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@tailwindcss/jit.svg" alt="License"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-    ![Tailwind CSS Just-In-Time](https://raw.githubusercontent.com/tailwindlabs/tailwindcss-jit/main/.github/logo.svg)
+    <img src="https://raw.githubusercontent.com/tailwindlabs/tailwindcss-jit/main/.github/logo.svg" alt="Tailwind CSS Just-In-Time">
 
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/releases"><img src="https://img.shields.io/npm/v/@tailwindcss/jit" alt="Latest Release"></a>
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@tailwindcss/jit.svg" alt="License"></a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 <p align="center">
     <img src="https://raw.githubusercontent.com/tailwindlabs/tailwindcss-jit/main/.github/logo.svg" alt="Tailwind CSS Just-In-Time">
+</p>
 
+<p align="center">
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/releases"><img src="https://img.shields.io/npm/v/@tailwindcss/jit" alt="Latest Release"></a>
     <a href="https://github.com/tailwindlabs/tailwindcss-jit/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@tailwindcss/jit.svg" alt="License"></a>
 </p>


### PR DESCRIPTION
This PR centers the readme banner ([see here](https://github.com/tailwindlabs/tailwindcss-jit/blob/fix-banner/README.md)) and uses an absolute URL for the image so it works outside of GitHub, like on [the npm website](https://www.npmjs.com/package/@tailwindcss/jit).