### PR TITLE
Arbitrary margin value proof of concept

### DIFF
--- a/src/corePlugins/margin.js
+++ b/src/corePlugins/margin.js
@@ -1,4 +1,4 @@
-const { asLength, nameClass } = require('../pluginUtils')
+const { asLength, nameClass, asValue } = require('../pluginUtils')
 
 module.exports = function ({ matchUtilities, jit: { theme } }) {
   matchUtilities({
@@ -34,7 +34,7 @@ module.exports = function ({ matchUtilities, jit: { theme } }) {
   })
   matchUtilities({
     mt: (modifier, { theme, candidate }) => {
-      let value = asLength(modifier, theme['margin'])
+      let value = asValue(modifier, theme['margin'])
 
       if (value === undefined) {
         return []

--- a/tests/08-arbitrary-values.test.css
+++ b/tests/08-arbitrary-values.test.css
@@ -7,6 +7,9 @@
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
 }
+.mt-\[clamp\(30px\2c 100px\)\] {
+	margin-top: clamp(30px, 100px);
+}
 .w-\[3\.23rem\] {
   width: 3.23rem;
 }

--- a/tests/08-arbitrary-values.test.html
+++ b/tests/08-arbitrary-values.test.html
@@ -22,5 +22,6 @@
     <div class="rotate-[23deg] rotate-[2.3rad] rotate-[401grad] rotate-[1.5turn]"></div>
     <div class="text-[2.23rem]"></div>
     <div class="duration-[2s]"></div>
+    <div class="mt-[clamp(30px,100px)]"></div>
   </body>
 </html>


### PR DESCRIPTION
Did I provide a test: **YES**
Do the tests pass: **YES**
Is this ready to merge: **NO**

I used what Adam did in #99 as inspiration for this PR.

I have updated the tests to include a proposed acceptance, though there is still more work to be done to add this support to the other utility classes. The test is definitely brittle.

Since this swaps out `asLength` for `asValue`, I'm guessing that might break something else in the framework, though the tests in this repo did not break. ¯\\\_(ツ)_/¯

I couldn't wrap my head around most of the source code, but I noticed in the `asValue()` helper function, that there is some special stuff going on for `calc()`. I wonder if all of the CSS functions could be supported using a similar method?

I also wonder if you can use `asLength` first, and if that returns `undefined` to then instead try and look for a supported list of arbitrary CSS functions? I know #102 mentions using `var()` and my example is `clamp()`

As a slight tangent, I think this would be super valuable to include, because of the utility of these arbitrary function values. Functions like `clamp`/`min`/`max` etc are extremely helpful for building custom one off design elements.

Great work on the JIT; Overall, it's awesome 🤘