### PR TITLE
Fixed issue with negative classes not being generated when used with a prefix.

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -140,9 +140,11 @@ function* resolveMatchedPlugins(classCandidate, context) {
   let candidatePrefix = classCandidate
   let negative = false
 
-  if (candidatePrefix[0] === '-') {
+  const twConfigPrefix = context.tailwindConfig.prefix || ''
+  const twConfigPrefixLen = twConfigPrefix.length
+  if (candidatePrefix[twConfigPrefixLen] === '-') {
     negative = true
-    candidatePrefix = candidatePrefix.slice(1)
+    candidatePrefix = twConfigPrefix + candidatePrefix.slice(twConfigPrefixLen + 1)
   }
 
   for (let [prefix, modifier] of candidatePermutations(candidatePrefix)) {

--- a/tests/05-prefix.test.css
+++ b/tests/05-prefix.test.css
@@ -47,6 +47,9 @@
 .tw-dark .tw-group:hover .custom-component {
   font-weight: 400;
 }
+.tw--ml-4 {
+  margin-left: -1rem;
+}
 .tw-font-bold {
   font-weight: 700;
 }
@@ -71,6 +74,12 @@
   text-align: left;
 }
 @media (min-width: 768px) {
+  .md\:tw--ml-5 {
+    margin-left: -1.25rem;
+  }
+  .md\:hover\:tw--ml-6:hover {
+    margin-left: -1.5rem;
+  }
   .md\:hover\:tw-text-right:hover {
     text-align: right;
   }

--- a/tests/05-prefix.test.html
+++ b/tests/05-prefix.test.html
@@ -1,3 +1,6 @@
+<div class="tw--ml-4"></div>
+<div class="md:tw--ml-5"></div>
+<div class="md:hover:tw--ml-6"></div>
 <div class="tw-container"></div>
 <div class="btn-no-prefix"></div>
 <div class="tw-btn-prefix"></div>


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/tailwindcss-jit/issues/42.

As far as I understood the code, it was checking for the first character to be a `-` to treat it as a negative class. However, it's not guaranteed that `-` will always be the first character as the user can freely set a prefix in their config file.

It follows, then, that a class will be negative if the first character after the prefix is `-`.

What we want to do here is 
1. let tailwind know that it needs to generate a negative class by setting the negative flag to true
2. retain the user defined prefix in `candidatePrefix` so that given a `tw--ml-4` class `tw-ml-4` can be passed to the generator 

From that point on the logic stays exactly the same, that is, when the negative flag is set, the modifier from the candidate will be prefixed with a `-`.

I've added a few test cases which seem to have run fine.

Let me know what you guys think.