### PR TITLE
feat: allow custom extractors

### DIFF
--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 const fastGlob = require('fast-glob')
 const sharedState = require('./sharedState')
 const { generateRules } = require('./generateRules')
@@ -7,10 +8,39 @@ const { bigSign } = require('./utils')
 let env = sharedState.env
 let contentMatchCache = sharedState.contentMatchCache
 
+const BROAD_MATCH_GLOBAL_REGEXP = /[^<>"'`\s]*[^<>"'`\s:]/g
+const INNER_MATCH_GLOBAL_REGEXP = /[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g
+
+function defaultJitExtractor(content) {
+  let broadMatches = content.match(BROAD_MATCH_GLOBAL_REGEXP) || []
+  let innerMatches = content.match(INNER_MATCH_GLOBAL_REGEXP) || []
+
+  return [...broadMatches, ...innerMatches]
+}
+
+function getExtractor(fileName, tailwindConfig) {
+  const purgeOptions = tailwindConfig && tailwindConfig.purge && tailwindConfig.purge.options
+
+  if (!purgeOptions) {
+    return defaultJitExtractor
+  }
+
+  const fileExtension = path.extname(fileName).slice(1)
+  const fileSpecificExtractor = (purgeOptions.extractors || []).find((extractor) =>
+    extractor.extensions.includes(fileExtension)
+  )
+
+  if (fileSpecificExtractor) {
+    return fileSpecificExtractor.extractor
+  }
+
+  return purgeOptions.defaultExtractor || defaultJitExtractor
+}
+
 // Scans template contents for possible classes. This is a hot path on initial build but
 // not too important for subsequent builds. The faster the better though — if we can speed
 // up these regexes by 50% that could cut initial build time by like 20%.
-function getClassCandidates(content, contentMatchCache, candidates, seen) {
+function getClassCandidates(content, extractor, contentMatchCache, candidates, seen) {
   for (let line of content.split('\n')) {
     line = line.trim()
 
@@ -24,20 +54,14 @@ function getClassCandidates(content, contentMatchCache, candidates, seen) {
         candidates.add(match)
       }
     } else {
-      let allMatches = new Set()
-      let broadMatches = line.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || []
-      let innerMatches = line.match(/[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g) || []
+      let extractorMatches = extractor(line)
+      let lineMatchesSet = new Set(extractorMatches)
 
-      for (let match of broadMatches) {
-        allMatches.add(match)
-        candidates.add(match)
-      }
-      for (let match of innerMatches) {
-        allMatches.add(match)
+      for (let match of lineMatchesSet) {
         candidates.add(match)
       }
 
-      contentMatchCache.set(line, allMatches)
+      contentMatchCache.set(line, lineMatchesSet)
     }
   }
 }
@@ -143,7 +167,8 @@ function expandTailwindAtRules(context, registerDependency) {
     env.DEBUG && console.time('Reading changed files')
     for (let file of context.changedFiles) {
       let content = fs.readFileSync(file, 'utf8')
-      getClassCandidates(content, contentMatchCache, candidates, seen)
+      let extractor = getExtractor(file, context.tailwindConfig)
+      getClassCandidates(content, extractor, contentMatchCache, candidates, seen)
     }
     env.DEBUG && console.timeEnd('Reading changed files')
 

--- a/tests/11-custom-extractors.test.css
+++ b/tests/11-custom-extractors.test.css
@@ -1,0 +1,17 @@
+* {
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+}
+.text-indigo-500 {
+  --tw-text-opacity: 1;
+  color: rgba(99, 102, 241, var(--tw-text-opacity));
+}

--- a/tests/11-custom-extractors.test.html
+++ b/tests/11-custom-extractors.test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Title</title>
+    <link rel="stylesheet" href="./tailwind.css" />
+  </head>
+  <body>
+    <div class="text-indigo-500 bg-white">hello world</div>
+    <span>text-red-500 shouldn't appear in the output</span>
+  </body>
+</html>

--- a/tests/11-custom-extractors.test.js
+++ b/tests/11-custom-extractors.test.js
@@ -1,0 +1,63 @@
+const postcss = require('postcss')
+const fs = require('fs')
+const path = require('path')
+
+function run(input, config = {}) {
+  jest.resetModules()
+  const tailwind = require('../src/index.js')
+  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+}
+
+function customExtractor(content) {
+  const matches = content.match(/class="([^"]+)"/)
+  return matches ? matches[1].split(/\s+/) : []
+}
+
+const css = `
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
+`
+const expectedPath = path.resolve(__dirname, './11-custom-extractors.test.css')
+const expected = fs.readFileSync(expectedPath, 'utf8')
+
+test('defaultExtractor', () => {
+  let config = {
+    purge: {
+      content: [path.resolve(__dirname, './11-custom-extractors.test.html')],
+      options: {
+        defaultExtractor: customExtractor,
+      },
+    },
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchCss(expected)
+  })
+})
+
+test('extractors array', () => {
+  let config = {
+    purge: {
+      content: [path.resolve(__dirname, './11-custom-extractors.test.html')],
+      options: {
+        extractors: [
+          {
+            extractor: customExtractor,
+            extensions: ['html'],
+          },
+        ],
+      },
+    },
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchCss(expected)
+  })
+})


### PR DESCRIPTION
I'm building a ui library using Tailwind which relies heavily on a custom [purge extractor](https://purgecss.com/extractors.html), which means I wouldn't be able to leverage `tailwindcss-jit` 😿 .

This PR aims to support custom extractors as defined in the purge config options if any, falling back to the default one from `tailwindcss-jit`.

I tried to make as few modifications as I could to the code

I'm hoping you're on board with the general idea 🙏 