### PR TITLE
Add TAILWIND_TOUCH_ROOT env var for custom touch dir

### DIFF
--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -31,8 +31,8 @@ let env = sharedState.env
 // Earmarks a directory for our touch files.
 // If the directory already exists we delete any existing touch files,
 // invalidating any caches associated with them.
-
-const touchDir = path.join(os.homedir() || os.tmpdir(), '.tailwindcss', 'touch')
+const touchDirRoot = process.env.TAILWIND_TOUCH_ROOT || os.homedir() || os.tmpdir()
+const touchDir = path.join(touchDirRoot, '.tailwindcss', 'touch')
 
 if (fs.existsSync(touchDir)) {
   for (let file of fs.readdirSync(touchDir)) {

--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -31,8 +31,8 @@ let env = sharedState.env
 // Earmarks a directory for our touch files.
 // If the directory already exists we delete any existing touch files,
 // invalidating any caches associated with them.
-const touchDirRoot = process.env.TAILWIND_TOUCH_ROOT || os.homedir() || os.tmpdir()
-const touchDir = path.join(touchDirRoot, '.tailwindcss', 'touch')
+const touchDir =
+  process.env.TAILWIND_TOUCH_DIR || path.join(os.homedir() || os.tmpdir(), '.tailwindcss', 'touch')
 
 if (fs.existsSync(touchDir)) {
   for (let file of fs.readdirSync(touchDir)) {


### PR DESCRIPTION
This PR adds the ability to specify a custom root path for `.tailwindcss` touch files directory. This will enable special environments with file system restrictions (like serverless environments) to be able to configure where these touch files are written to.

I believe an option like this will be needed if the [Tailwind Play](https://github.com/tailwindlabs/play.tailwindcss.com) project is updated to use JIT since it's deployed to Vercel. Vercel serverless functions can only write to the `/tmp` directory but in most other environments it makes most sense to put touch files in the `$HOME` directory.