### PR TITLE
Add error messages for nested at-rules & apply

### DIFF
--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -158,12 +158,14 @@ function processApply(root, context) {
           const screenType = apply.parent.params
 
           throw apply.error(
-            `@apply nested inside @screen is not supported. We suggest you write this as @apply ${applyCandidates.map(c => `${screenType}:${c}`).join(' ')} instead.`
+            `@apply is not supported within nested at-rules like @screen. We suggest you write this as @apply ${applyCandidates
+              .map((c) => `${screenType}:${c}`)
+              .join(' ')} instead.`
           )
         }
 
         throw apply.error(
-          `@apply only works for elements and classes. Nesting inside an @${apply.parent.name} is not supported. Please move the @${apply.parent.name} around the element/class selector`
+          `@apply is not supported within nested at-rules like @${apply.parent.name}. You can fix this by un-nesting @${apply.parent.name}.`
         )
       }
 

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -154,6 +154,14 @@ function processApply(root, context) {
       let [applyCandidates, important] = extractApplyCandidates(apply.params)
 
       if (apply.parent.type === 'atrule') {
+        if (apply.parent.name === 'screen') {
+          const screenType = apply.parent.params
+
+          throw apply.error(
+            `@apply nested inside @screen is not supported. We suggest you write this as @apply ${applyCandidates.map(c => `${screenType}:${c}`).join(' ')} instead.`
+          )
+        }
+
         throw apply.error(
           `@apply only works for elements and classes. Nesting inside an @${apply.parent.name} is not supported. Please move the @${apply.parent.name} around the element/class selector`
         )

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -153,6 +153,12 @@ function processApply(root, context) {
 
       let [applyCandidates, important] = extractApplyCandidates(apply.params)
 
+      if (apply.parent.type === 'atrule') {
+        throw apply.error(
+          `@apply only works for elements and classes. Nesting inside an @${apply.parent.name} is not supported. Please move the @${apply.parent.name} around the element/class selector`
+        )
+      }
+
       for (let applyCandidate of applyCandidates) {
         if (!applyClassCache.has(applyCandidate)) {
           throw apply.error(

--- a/tests/10-apply.test.js
+++ b/tests/10-apply.test.js
@@ -7,7 +7,7 @@ function run(input, config = {}) {
   const { currentTestName } = expect.getState()
 
   return postcss([tailwind(config)]).process(input, {
-    from: `${path.resolve(__filename)}?test=${currentTestName}`
+    from: `${path.resolve(__filename)}?test=${currentTestName}`,
   })
 }
 
@@ -162,7 +162,7 @@ test('@apply error with unknown utility', async () => {
   }
 `
 
-  await expect(run(css, config)).rejects.toThrowError("class does not exist")
+  await expect(run(css, config)).rejects.toThrowError('class does not exist')
 })
 
 test('@apply error with nested @screen', async () => {
@@ -186,7 +186,9 @@ test('@apply error with nested @screen', async () => {
   }
 `
 
-  await expect(run(css, config)).rejects.toThrowError("@apply nested inside @screen is not supported")
+  await expect(run(css, config)).rejects.toThrowError(
+    '@apply is not supported within nested at-rules like @screen'
+  )
 })
 
 test('@apply error with nested @anyatrulehere', async () => {
@@ -210,5 +212,7 @@ test('@apply error with nested @anyatrulehere', async () => {
   }
 `
 
-  await expect(run(css, config)).rejects.toThrowError("Nesting inside an @genie is not supported")
+  await expect(run(css, config)).rejects.toThrowError(
+    '@apply is not supported within nested at-rules like @genie'
+  )
 })

--- a/tests/10-apply.test.js
+++ b/tests/10-apply.test.js
@@ -4,7 +4,11 @@ const fs = require('fs')
 const path = require('path')
 
 function run(input, config = {}) {
-  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+  const { currentTestName } = expect.getState()
+
+  return postcss([tailwind(config)]).process(input, {
+    from: `${path.resolve(__filename)}?test=${currentTestName}`
+  })
 }
 
 test('@apply', () => {
@@ -141,9 +145,6 @@ test('@apply', () => {
 
 test('@apply error with unknown utility', async () => {
   let config = {
-    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
-    __name: "unknown-utility",
-
     darkMode: 'class',
     purge: [path.resolve(__dirname, './10-apply.test.html')],
     corePlugins: { preflight: false },
@@ -166,9 +167,6 @@ test('@apply error with unknown utility', async () => {
 
 test('@apply error with nested @screen', async () => {
   let config = {
-    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
-    __name: "at-screen",
-
     darkMode: 'class',
     purge: [path.resolve(__dirname, './10-apply.test.html')],
     corePlugins: { preflight: false },
@@ -193,9 +191,6 @@ test('@apply error with nested @screen', async () => {
 
 test('@apply error with nested @anyatrulehere', async () => {
   let config = {
-    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
-    __name: "at-anything",
-
     darkMode: 'class',
     purge: [path.resolve(__dirname, './10-apply.test.html')],
     corePlugins: { preflight: false },

--- a/tests/10-apply.test.js
+++ b/tests/10-apply.test.js
@@ -163,3 +163,29 @@ test('@apply error with unknown utility', async () => {
 
   await expect(run(css, config)).rejects.toThrowError("class does not exist")
 })
+test('@apply error with nested @anyatrulehere', async () => {
+  let config = {
+    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
+    __name: "at-anything",
+
+    darkMode: 'class',
+    purge: [path.resolve(__dirname, './10-apply.test.html')],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let css = `
+  @tailwind components;
+  @tailwind utilities;
+
+  @layer components {
+    .foo {
+      @genie {
+        @apply text-black;
+      }
+    }
+  }
+`
+
+  await expect(run(css, config)).rejects.toThrowError("Nesting inside an @genie is not supported")
+})

--- a/tests/10-apply.test.js
+++ b/tests/10-apply.test.js
@@ -139,4 +139,27 @@ test('@apply', () => {
   })
 })
 
-// TODO: Test stuff that should throw
+test('@apply error with unknown utility', async () => {
+  let config = {
+    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
+    __name: "unknown-utility",
+
+    darkMode: 'class',
+    purge: [path.resolve(__dirname, './10-apply.test.html')],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let css = `
+  @tailwind components;
+  @tailwind utilities;
+
+  @layer components {
+    .foo {
+      @apply a-utility-that-does-not-exist;
+    }
+  }
+`
+
+  await expect(run(css, config)).rejects.toThrowError("class does not exist")
+})

--- a/tests/10-apply.test.js
+++ b/tests/10-apply.test.js
@@ -163,6 +163,34 @@ test('@apply error with unknown utility', async () => {
 
   await expect(run(css, config)).rejects.toThrowError("class does not exist")
 })
+
+test('@apply error with nested @screen', async () => {
+  let config = {
+    // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.
+    __name: "at-screen",
+
+    darkMode: 'class',
+    purge: [path.resolve(__dirname, './10-apply.test.html')],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let css = `
+  @tailwind components;
+  @tailwind utilities;
+
+  @layer components {
+    .foo {
+      @screen md {
+        @apply text-black;
+      }
+    }
+  }
+`
+
+  await expect(run(css, config)).rejects.toThrowError("@apply nested inside @screen is not supported")
+})
+
 test('@apply error with nested @anyatrulehere', async () => {
   let config = {
     // TODO: Remove this. Some kind of caching causes multiple tests in the same file to break.


### PR DESCRIPTION
This adds error messages when nesting `@apply` inside `@screen` (or any other at rule for that matter).

Closes #76 (I think)