### PR TITLE
fix: avoid infinite loop for square brackets custom modifier

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -23,7 +23,7 @@ function* candidatePermutations(candidate, lastIndex = Infinity) {
 
   let dashIdx
 
-  if (candidate.endsWith(']')) {
+  if (candidate.endsWith(']', /*length*/ lastIndex + 1)) {
     dashIdx = candidate.lastIndexOf('[') - 1
   } else {
     dashIdx = candidate.lastIndexOf('-', lastIndex)
@@ -33,7 +33,7 @@ function* candidatePermutations(candidate, lastIndex = Infinity) {
     return
   }
 
-  let prefix = candidate.slice(0, dashIdx)
+  let prefix = candidate.slice(0, candidate.charAt(dashIdx) === '-' ? dashIdx : dashIdx + 1)
   let modifier = candidate.slice(dashIdx + 1)
 
   yield [prefix, modifier]


### PR DESCRIPTION
Fixes #165 and fixes #166 and fixes #168
We check for square brackets at the end of the string only on the first iteration to avoid infinite loops.
Furthermore we correctly return `prefix` and` modifier` for:
```diff
string[]
- strin []
+ string []
```