### PR TITLE
Add `!font-bold`-style important modifier

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -71,7 +71,7 @@ function applyImportant(matches) {
   }
   let result = []
 
-  for (let [{ sort, layer, options }, rule] of matches) {
+  for (let [meta, rule] of matches) {
     let container = postcss.root({ nodes: [rule] })
     container.walkRules((r) => {
       r.selector = updateAllClasses(r.selector, (className) => {
@@ -79,8 +79,7 @@ function applyImportant(matches) {
       })
       r.walkDecls((d) => (d.important = true))
     })
-    let withOffset = [{ sort: sort, layer, options }, container.nodes[0]]
-    result.push(withOffset)
+    result.push([meta, container.nodes[0]])
   }
 
   return result
@@ -177,9 +176,8 @@ function* resolveMatchedPlugins(classCandidate, context) {
   let candidatePrefix = classCandidate
   let negative = false
 
-  let twConfigPrefix = context.tailwindConfig.prefix || ''
-  let twConfigPrefixLen = twConfigPrefix.length
-
+  const twConfigPrefix = context.tailwindConfig.prefix || ''
+  const twConfigPrefixLen = twConfigPrefix.length
   if (candidatePrefix[twConfigPrefixLen] === '-') {
     negative = true
     candidatePrefix = twConfigPrefix + candidatePrefix.slice(twConfigPrefixLen + 1)

--- a/tests/14-important-modifier.test.css
+++ b/tests/14-important-modifier.test.css
@@ -1,0 +1,53 @@
+* {
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+.\!container {
+  width: 100% !important;
+}
+@media (min-width: 640px) {
+  .\!container {
+    max-width: 640px !important;
+  }
+}
+@media (min-width: 768px) {
+  .\!container {
+    max-width: 768px !important;
+  }
+}
+@media (min-width: 1024px) {
+  .\!container {
+    max-width: 1024px !important;
+  }
+}
+@media (min-width: 1280px) {
+  .\!container {
+    max-width: 1280px !important;
+  }
+}
+@media (min-width: 1536px) {
+  .\!container {
+    max-width: 1536px !important;
+  }
+}
+.\!font-bold {
+  font-weight: 700 !important;
+}
+.hover\:\!text-center:hover {
+  text-align: center !important;
+}
+@media (min-width: 1024px) {
+  .lg\:\!opacity-50 {
+    opacity: 0.5 !important;
+  }
+}
+@media (min-width: 1280px) {
+  .xl\:focus\:disabled\:\!float-right:focus:disabled {
+    float: right !important;
+  }
+}

--- a/tests/14-important-modifier.test.html
+++ b/tests/14-important-modifier.test.html
@@ -1,0 +1,5 @@
+<div class="!container"></div>
+<div class="!font-bold"></div>
+<div class="hover:!text-center"></div>
+<div class="lg:!opacity-50"></div>
+<div class="xl:focus:disabled:!float-right"></div>

--- a/tests/14-important-modifier.test.js
+++ b/tests/14-important-modifier.test.js
@@ -1,0 +1,32 @@
+const postcss = require('postcss')
+const tailwind = require('../src/index.js')
+const fs = require('fs')
+const path = require('path')
+
+function run(input, config = {}) {
+  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+}
+
+test('important boolean', () => {
+  let config = {
+    important: false,
+    darkMode: 'class',
+    purge: [path.resolve(__dirname, './14-important-modifier.test.html')],
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(css, config).then((result) => {
+    let expectedPath = path.resolve(__dirname, './14-important-modifier.test.css')
+    let expected = fs.readFileSync(expectedPath, 'utf8')
+
+    expect(result.css).toMatchCss(expected)
+  })
+})

--- a/tests/15-important-modifier-prefix.test.css
+++ b/tests/15-important-modifier-prefix.test.css
@@ -1,0 +1,53 @@
+* {
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+.\!tw-container {
+  width: 100% !important;
+}
+@media (min-width: 640px) {
+  .\!tw-container {
+    max-width: 640px !important;
+  }
+}
+@media (min-width: 768px) {
+  .\!tw-container {
+    max-width: 768px !important;
+  }
+}
+@media (min-width: 1024px) {
+  .\!tw-container {
+    max-width: 1024px !important;
+  }
+}
+@media (min-width: 1280px) {
+  .\!tw-container {
+    max-width: 1280px !important;
+  }
+}
+@media (min-width: 1536px) {
+  .\!tw-container {
+    max-width: 1536px !important;
+  }
+}
+.\!tw-font-bold {
+  font-weight: 700 !important;
+}
+.hover\:\!tw-text-center:hover {
+  text-align: center !important;
+}
+@media (min-width: 1024px) {
+  .lg\:\!tw-opacity-50 {
+    opacity: 0.5 !important;
+  }
+}
+@media (min-width: 1280px) {
+  .xl\:focus\:disabled\:\!tw-float-right:focus:disabled {
+    float: right !important;
+  }
+}

--- a/tests/15-important-modifier-prefix.test.html
+++ b/tests/15-important-modifier-prefix.test.html
@@ -1,0 +1,5 @@
+<div class="!tw-container"></div>
+<div class="!tw-font-bold"></div>
+<div class="hover:!tw-text-center"></div>
+<div class="lg:!tw-opacity-50"></div>
+<div class="xl:focus:disabled:!tw-float-right"></div>

--- a/tests/15-important-modifier-prefix.test.js
+++ b/tests/15-important-modifier-prefix.test.js
@@ -7,11 +7,12 @@ function run(input, config = {}) {
   return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
 }
 
-test('important modifier', () => {
+test('important modifier with prefix', () => {
   let config = {
     important: false,
+    prefix: 'tw-',
     darkMode: 'class',
-    purge: [path.resolve(__dirname, './14-important-modifier.test.html')],
+    purge: [path.resolve(__dirname, './15-important-modifier-prefix.test.html')],
     corePlugins: { preflight: false },
     theme: {},
     plugins: [],
@@ -24,7 +25,7 @@ test('important modifier', () => {
   `
 
   return run(css, config).then((result) => {
-    let expectedPath = path.resolve(__dirname, './14-important-modifier.test.css')
+    let expectedPath = path.resolve(__dirname, './15-important-modifier-prefix.test.css')
     let expected = fs.readFileSync(expectedPath, 'utf8')
 
     expect(result.css).toMatchCss(expected)


### PR DESCRIPTION
Resolves #92, resolves #34.

This PR adds support for making any utility "important" by throwing a `!` at the beginning:

```html
<p class="font-bold !font-medium">
  This will be medium even though bold comes later in the CSS.
</p>
```

This matches the syntax we have been showing as an example of custom variants in the official documentation for the last 500 years:

<img width="850" alt="image" src="https://user-images.githubusercontent.com/4323180/112737624-37aaa880-8f32-11eb-8706-e3d90c75ff43.png">

As well as the syntax Netlify is using as they [refactor their codebase](https://www.netlify.com/blog/2021/03/23/from-semantic-css-to-tailwind-refactoring-the-netlify-ui-codebase/) to Tailwind:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/4323180/112737636-485b1e80-8f32-11eb-9d7c-87bc4328bcd1.png">

There are probably weird things you can do with your CSS that will make this break, but that's why we release it and let everyone do their worst and see what is reported 😄

In the future I could see a world where instead of making things `!important` we use the `:is` selector and a private ID to boost the specificity without introducing conflicts with inline styles:

```css
:is(#__tw, .\!font-bold) {
  font-weight: 700;
}
```

Browser support is pretty good for this but might want to wait until Safari 12/13 are a little more dead.
