### PR TITLE
Add support for selectors in `important` option

### DIFF
--- a/tests/important-selector.test.css
+++ b/tests/important-selector.test.css
@@ -1,0 +1,85 @@
+* {
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+.container {
+  width: 100%;
+}
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+#app .btn {
+  button: yes;
+}
+@font-face {
+  font-family: Inter;
+}
+@page {
+  margin: 1cm;
+}
+.custom-component {
+  font-weight: 700;
+}
+.custom-important-component {
+  text-align: center !important;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+#app .animate-spin {
+  animation: spin 1s linear infinite;
+}
+#app .font-bold {
+  font-weight: 700;
+}
+.custom-util {
+  button: no;
+}
+#app .group:hover .group-hover\:focus-within\:text-left:focus-within {
+  text-align: left;
+}
+#app [dir='rtl'] .rtl\:active\:text-center:active {
+  text-align: center;
+}
+@media (prefers-reduced-motion: no-preference) {
+  #app .motion-safe\:hover\:text-center:hover {
+    text-align: center;
+  }
+}
+#app .dark .dark\:focus\:text-left:focus {
+  text-align: left;
+}
+@media (min-width: 768px) {
+  #app .md\:hover\:text-right:hover {
+    text-align: right;
+  }
+}

--- a/tests/important-selector.test.html
+++ b/tests/important-selector.test.html
@@ -1,0 +1,12 @@
+<div class="container"></div>
+<div class="btn"></div>
+<div class="animate-spin"></div>
+<div class="custom-util"></div>
+<div class="custom-component"></div>
+<div class="custom-important-component"></div>
+<div class="font-bold"></div>
+<div class="md:hover:text-right"></div>
+<div class="motion-safe:hover:text-center"></div>
+<div class="dark:focus:text-left"></div>
+<div class="group-hover:focus-within:text-left"></div>
+<div class="rtl:active:text-center"></div>

--- a/tests/important-selector.test.js
+++ b/tests/important-selector.test.js
@@ -1,0 +1,70 @@
+const postcss = require('postcss')
+const tailwind = require('../src/index.js')
+const fs = require('fs')
+const path = require('path')
+
+function run(input, config = {}) {
+  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+}
+
+test('important selector', () => {
+  let config = {
+    important: '#app',
+    darkMode: 'class',
+    purge: [path.resolve(__dirname, './important-selector.test.html')],
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [
+      function ({ addComponents, addUtilities }) {
+        addComponents(
+          {
+            '.btn': {
+              button: 'yes',
+            },
+          },
+          { respectImportant: true }
+        )
+        addComponents(
+          {
+            '@font-face': {
+              'font-family': 'Inter',
+            },
+            '@page': {
+              margin: '1cm',
+            },
+          },
+          { respectImportant: true }
+        )
+        addUtilities(
+          {
+            '.custom-util': {
+              button: 'no',
+            },
+          },
+          { respectImportant: false }
+        )
+      },
+    ],
+  }
+
+  let css = `
+    @tailwind base;
+    @tailwind components;
+    @layer components {
+      .custom-component {
+        @apply font-bold;
+      }
+      .custom-important-component {
+        @apply text-center !important;
+      }
+    }
+    @tailwind utilities;
+  `
+
+  return run(css, config).then((result) => {
+    let expectedPath = path.resolve(__dirname, './important-selector.test.css')
+    let expected = fs.readFileSync(expectedPath, 'utf8')
+
+    expect(result.css).toMatchCss(expected)
+  })
+})


### PR DESCRIPTION
This PR adds support for using a selector in the `important` option to increase specificity without actually making things important.

This is an existing feature in Tailwind that hadn't yet been ported to the JIT engine — [see the documentation to learn more about how it works](https://tailwindcss.com/docs/configuration#selector-strategy).