### PR TITLE
Add support for prefix as a function

### DIFF
--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -401,7 +401,11 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
       return '*'
     }
 
-    return options.respectPrefix ? context.tailwindConfig.prefix + identifier : identifier
+    if (! options.respectPrefix) {
+      return identifier
+    }
+
+    return context.tailwindConfig.prefix + identifier
   }
 
   return {

--- a/src/lib/setupContext.js
+++ b/src/lib/setupContext.js
@@ -405,6 +405,10 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
       return identifier
     }
 
+    if (typeof context.tailwindConfig.prefix === 'function') {
+      return prefixSelector(context.tailwindConfig.prefix, `.${identifier}`).substr(1)
+    }
+
     return context.tailwindConfig.prefix + identifier
   }
 

--- a/tests/prefix.fn.test.css
+++ b/tests/prefix.fn.test.css
@@ -1,0 +1,9 @@
+.tw-ml-1 {
+  margin-left: 0.25rem;
+}
+.flex {
+  display: flex;
+}
+.tw-align-bottom {
+  vertical-align: bottom
+}

--- a/tests/prefix.fn.test.html
+++ b/tests/prefix.fn.test.html
@@ -1,0 +1,3 @@
+<div class="flex"></div>
+<div class="tw-align-bottom"></div>
+<div class="tw-ml-1"></div>

--- a/tests/prefix.fn.test.js
+++ b/tests/prefix.fn.test.js
@@ -1,0 +1,34 @@
+const postcss = require('postcss')
+const tailwind = require('../src/index.js')
+const fs = require('fs')
+const path = require('path')
+
+function run(input, config = {}) {
+  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+}
+
+test('prefix fn', () => {
+  let config = {
+    prefix(selector) {
+      if (['.align-bottom', '.ml'].some(prefix => selector.startsWith(prefix))) {
+        return 'tw-';
+      }
+
+      return '';
+    },
+    purge: [path.resolve(__dirname, './prefix.fn.test.html')],
+    corePlugins: { preflight: false },
+    theme: {},
+  }
+
+  let css = `
+    @tailwind utilities;
+  `
+
+  return run(css, config).then((result) => {
+    let expectedPath = path.resolve(__dirname, './prefix.fn.test.css')
+    let expected = fs.readFileSync(expectedPath, 'utf8')
+
+    expect(result.css).toMatchCss(expected)
+  })
+})


### PR DESCRIPTION
Closes #159

Due to the implementation of the JIT we must support utility class prefixes in addition to the selectors themselves.

For example for .tw-ml-1 we'd pass .ml and .ml-1 to the prefix function. This is a byproduct of how we handle matching of classes before we generate the rules.

Because of this we'll want to encourage people to use a `startsWith` check instead of equality or includes:
```js
prefix(selector) {
  if (['.align-bottom', '.ml'].some(prefix => selector.startsWith(prefix))) {
    return 'tw-';
  }

  return '';
},
```

You can also do this using an anchored regular expression which can be shorter:
```js
prefix(selector) {
  if (/^\.(align-bottom|ml)/.test(selector)) {
    return 'tw-';
  }

  return '';
},
```