### PR TITLE
Fallback to non variant matches when no matching variant exists

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -146,7 +146,7 @@ function applyVariant(variant, matches, context) {
     return result
   }
 
-  return []
+  return matches
 }
 
 function parseRules(rule, cache, options = {}) {

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -267,6 +267,7 @@ function inKeyframes(rule) {
 
 function generateRules(candidates, context) {
   let allRules = []
+  let allSelectors = new Set()
 
   for (let candidate of candidates) {
     if (context.notClassCache.has(candidate)) {
@@ -285,8 +286,19 @@ function generateRules(candidates, context) {
       continue
     }
 
+    matches = matches.filter(([_, rule]) => {
+      return !rule.selector
+          || !allSelectors.has(rule.selector)
+    })
+
     context.classCache.set(candidate, matches)
     allRules.push(...matches)
+
+    matches.forEach(([_, rule]) => {
+      if (rule.selector) {
+        allSelectors.add(rule.selector)
+      }
+    })
   }
 
   return allRules.map(([{ sort, layer, options }, rule]) => {

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -274,7 +274,7 @@ function generateRules(candidates, context) {
     }
 
     if (context.classCache.has(candidate)) {
-      allRules.push(context.classCache.get(candidate))
+      allRules.push(...context.classCache.get(candidate))
       continue
     }
 
@@ -286,10 +286,10 @@ function generateRules(candidates, context) {
     }
 
     context.classCache.set(candidate, matches)
-    allRules.push(matches)
+    allRules.push(...matches)
   }
 
-  return allRules.flat(1).map(([{ sort, layer, options }, rule]) => {
+  return allRules.map(([{ sort, layer, options }, rule]) => {
     if (options.respectImportant) {
       if (context.tailwindConfig.important === true) {
         rule.walkDecls((d) => {

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -7,6 +7,10 @@
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
 }
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgba(59, 130, 246, var(--tw-text-opacity));
+}
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -67,5 +67,7 @@
 
     <!-- Things that look like variants but are not -->
     <h1 class:text-blue-500={shouldBeBlue}></h1>
+    <h1 class1:text-blue-500={shouldBeBlue}></h1>
+    <h1 class2:text-blue-500={shouldBeBlue}></h1>
   </body>
 </html>

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -64,5 +64,8 @@
     <div class="lg:dark:shadow-md"></div>
     <div class="xl:dark:disabledshadow-md"></div>
     <div class="2xl:dark:motion-safe:focus-within:shadow-md"></div>
+
+    <!-- Things that look like variants but are not -->
+    <h1 class:text-blue-500={shouldBeBlue}></h1>
   </body>
 </html>


### PR DESCRIPTION
Closes #71

Svelte’s dynamic class syntax looks like this:
`<h1 class:text-blue-500={shouldBeBlue}></h1>`

We were picking up `class:text-blue-500` as a variant. However `class` is not a registered variant. In this case we were discarding the already matched rules for text-blue-500. In this case we want to match them anyway.
