### PR TITLE
Support Svelte 'class:' syntax

### DIFF
--- a/tests/svelte-syntax.test.css
+++ b/tests/svelte-syntax.test.css
@@ -1,0 +1,15 @@
+* {
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+@media (min-width: 1024px) {
+  .lg\:hover\:bg-blue-500:hover {
+    --tw-bg-opacity: 1;
+    background-color: rgba(59, 130, 246, var(--tw-bg-opacity));
+  }
+}

--- a/tests/svelte-syntax.test.js
+++ b/tests/svelte-syntax.test.js
@@ -1,0 +1,30 @@
+const postcss = require('postcss')
+const tailwind = require('../src/index.js')
+const fs = require('fs')
+const path = require('path')
+
+function run(input, config = {}) {
+  return postcss([tailwind(config)]).process(input, { from: path.resolve(__filename) })
+}
+
+test('basic usage', () => {
+  let config = {
+    purge: [path.resolve(__dirname, './svelte-syntax.test.svelte')],
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(css, config).then((result) => {
+    let expectedPath = path.resolve(__dirname, './svelte-syntax.test.css')
+    let expected = fs.readFileSync(expectedPath, 'utf8')
+
+    expect(result.css).toMatchCss(expected)
+  })
+})

--- a/tests/svelte-syntax.test.svelte
+++ b/tests/svelte-syntax.test.svelte
@@ -1,0 +1,5 @@
+<script>
+  let current = 'foo'
+</script>
+
+<button class:lg:hover:bg-blue-500={current === 'foo'}>Click me</button>


### PR DESCRIPTION
This PR is an alternative to #178 that is a bit simpler, and just adds a little bit of Svelte-specific awareness to our internals to strip off any leading `class:` only when reading a `.svelte` file. There is a tiny performance cost to this, which is why I've opted to do it only on `.svelte` files and not on all files.

I believe some older Svelte projects might use `.html` as the file extension for Svelte stuff — personally I am totally comfortable telling those people to change the file extension if they need this feature or to override the default extractor.